### PR TITLE
Unable to load `prod.keys` from `~/.switch` folder due to incorrect file-exists checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix loading of `prod.keys` from the `~/.switch` folder due to incorrect file-exists checks.
+
 ## [1.2.0] - 2022-11-13
 
 ### Added

--- a/nton/constants.py
+++ b/nton/constants.py
@@ -28,10 +28,9 @@ class Binaries:
 class Files:
     keys_home = (Path.home() / ".switch" / "prod.keys")
     keys_cwd = Path("./prod.keys").absolute()
-    keys_exist = keys_home.is_file() or keys_cwd.is_file()
     keys = keys_cwd if keys_cwd.is_file() else keys_home
 
 
-if not Files.keys_exist:
+if not Files.keys:
     print(f"!! prod.keys is missing! Please place it in the current working directory or at \"{Files.keys_home}\"")
     sys.exit(1)

--- a/nton/constants.py
+++ b/nton/constants.py
@@ -28,9 +28,10 @@ class Binaries:
 class Files:
     keys_home = (Path.home() / ".switch" / "prod.keys")
     keys_cwd = Path("./prod.keys").absolute()
-    keys = keys_cwd or keys_home
+    keys_exist = keys_home.is_file() or keys_cwd.is_file()
+    keys = keys_cwd if keys_cwd.is_file() else keys_home
 
 
-if not Files.keys.is_file():
+if not Files.keys_exist:
     print(f"!! prod.keys is missing! Please place it in the current working directory or at \"{Files.keys_home}\"")
     sys.exit(1)


### PR DESCRIPTION
Hi, don't know if I'm the only user having an issue but your logic seems off.

https://github.com/rlaphoenix/nton/blob/e9e512eb0a466e13990d2cc01a56c75e9c6e022a/nton/constants.py#L31

In this line you always have `keys = keys_cwd` because keys_cwd is always set.
Not with an existing file but a path. It doesn't matter the file is not existing.
So in my case the the prod.keys file is at the correct location but since I'm not in the .switch directory the check fails.

kind regards and thanks for your work